### PR TITLE
Corrected variable typo

### DIFF
--- a/src/Service/DomainrobotService.php
+++ b/src/Service/DomainrobotService.php
@@ -30,7 +30,7 @@ class DomainrobotService
     protected $guzzleClientConfig;
 
     private $logRequestCallback = null;
-    private $logReesponseCallback = null;
+    private $logResponseCallback = null;
 
     public function __construct(DomainrobotConfig $domainrobotConfig)
     {


### PR DESCRIPTION
$logReesponseCallback corrected to $logResponseCallback. Otherwise search is giving "Undefined property: Domainrobot\Service\DomainStudioService::$logResponseCallback" and crashes.