### PR TITLE
Correcting errors reported by Phan PHP static analyzer

### DIFF
--- a/src/Service/CertificateService.php
+++ b/src/Service/CertificateService.php
@@ -14,7 +14,6 @@ use Domainrobot\Service\DomainrobotService;
 
 class CertificateService extends DomainrobotService
 {
-
     /**
      *
      * @param DomainrobotConfig $domainrobotConfig
@@ -30,7 +29,7 @@ class CertificateService extends DomainrobotService
      * for polling.
      *
      * @param Certificate $body
-     * @return Objectjob
+     * @return ObjectJob
      */
     public function create(Certificate $body)
     {
@@ -43,6 +42,7 @@ class CertificateService extends DomainrobotService
             "job" => ArrayHelper::getValueFromArray($domainrobotResult->getResult(), 'data.0.id', '')
         ]);
     }
+
     /**
      * Orders a certificate. The prepareOrder tasks should be called before to
      * generate the necessary DCV data. Returns a Job with an id that can be used
@@ -56,7 +56,7 @@ class CertificateService extends DomainrobotService
         $this->prepareCsr($body);
 
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/certificate",
+            $this->domainrobotConfig->getUrl() . "/certificate",
             'POST',
             ["json" => $body->toArray(true)]
         );
@@ -97,11 +97,12 @@ class CertificateService extends DomainrobotService
         $this->prepareCsr($body);
 
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/certificate/_realtime",
+            $this->domainrobotConfig->getUrl() . "/certificate/_realtime",
             'POST',
             ["json" => $body->toArray(true)]
         );
     }
+
     /**
      * Check the csr and generate DCV data for an order, renew and reissue. This
      * should be called everytime before the following tasks :
@@ -116,7 +117,7 @@ class CertificateService extends DomainrobotService
      */
     public function prepareOrder(CertificateData $body)
     {
-        $domainrobotPromise = $this->prepareOrderAsync();
+        $domainrobotPromise = $this->prepareOrderAsync($body);
         $domainrobotResult = $domainrobotPromise->wait();
 
         Domainrobot::setLastDomainrobotResult($domainrobotResult);
@@ -141,7 +142,7 @@ class CertificateService extends DomainrobotService
         //$this->prepareCsr();
 
         return new DomainrobotPromise($this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/certificate/_prepareOrder",
+            $this->domainrobotConfig->getUrl() . "/certificate/_prepareOrder",
             'POST',
             ["json" => $body->toArray(true)]
         ));
@@ -167,7 +168,7 @@ class CertificateService extends DomainrobotService
      * * updated
      * * authentication
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return Certificate[]
      */
     public function list(Query $body = null)
@@ -205,18 +206,18 @@ class CertificateService extends DomainrobotService
      * * updated
      * * authentication
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return DomainrobotPromise
      */
 
     public function listAsync(Query $body = null)
     {
         $data = null;
-        if ($query != null) {
+        if ($body != null) {
             $data = $body->toArray(true);
         }
         return new DomainrobotPromise($this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/certificate/_search",
+            $this->domainrobotConfig->getUrl() . "/certificate/_search",
             'POST',
             ["json" => $data]
         ));
@@ -225,7 +226,7 @@ class CertificateService extends DomainrobotService
     /**
      * Fetches the information for an existing certificate.
      *
-     * @param [int] $id
+     * @param int $id
      * @return Certificate
      */
     public function info($id)
@@ -240,13 +241,13 @@ class CertificateService extends DomainrobotService
     /**
      * Fetches the information for an existing certificate.
      *
-     * @param [int] $id
+     * @param int $id
      * @return DomainrobotPromise
      */
     public function infoAsync($id)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/certificate/$id",
+            $this->domainrobotConfig->getUrl() . "/certificate/$id",
             'GET'
         );
     }
@@ -255,7 +256,7 @@ class CertificateService extends DomainrobotService
      * Deletes an existing certificate. Returns a Job with an id that can be used
      * for polling.
      *
-     * @param [int] $id
+     * @param int $id
      * @return ObjectJob
      */
     public function delete($id)
@@ -273,13 +274,13 @@ class CertificateService extends DomainrobotService
      * Deletes an existing certificate. Returns a Job with an id that can be used
      * for polling.
      *
-     * @param [int] $id
+     * @param int $id
      * @return DomainrobotPromise
      */
     public function deleteAsync($id)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/certificate/$id",
+            $this->domainrobotConfig->getUrl() . "/certificate/$id",
             'DELETE'
         );
     }
@@ -316,12 +317,12 @@ class CertificateService extends DomainrobotService
     public function reissueAsync(Certificate $body)
     {
         if ($body->getId() === null) {
-            throw InvalidArgumentException("Field Certificate.id is missing.");
+            throw new \InvalidArgumentException("Field Certificate.id is missing.");
         }
         $this->prepareCsr($body);
 
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/certificate/".$body->getId(),
+            $this->domainrobotConfig->getUrl() . "/certificate/".$body->getId(),
             'PUT',
             ["json" => $body->toArray(true)]
         );
@@ -359,12 +360,12 @@ class CertificateService extends DomainrobotService
     public function renewAsync(Certificate $body)
     {
         if ($body->getId() === null) {
-            throw InvalidArgumentException("Field Certificate.id is missing.");
+            throw new \InvalidArgumentException("Field Certificate.id is missing.");
         }
         $this->prepareCsr($body);
 
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/certificate/".$body->getId()."/_renew",
+            $this->domainrobotConfig->getUrl() . "/certificate/".$body->getId()."/_renew",
             'PUT',
             ["json" => $body->toArray(true)]
         );
@@ -373,8 +374,9 @@ class CertificateService extends DomainrobotService
     /**
      * Updates the comment for an existing certificate.
      *
-     * @param [int] $id, [string] comment
-     * @return
+     * @param int $id
+     * @param string $comment
+     * @return void
      */
     public function commentUpdate($id, $comment)
     {
@@ -387,14 +389,15 @@ class CertificateService extends DomainrobotService
     /**
      * Updates the comment for an existing certificate.
      *
-     * @param [int] $id, [string] comment
-     * @return
+     * @param int $id
+     * @param string $comment
+     * @return DomainrobotPromise
      */
     public function commentUpdateAsync($id, $comment)
     {
         $cert = new Certificate(['comment' => $comment]);
-        $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/certificate/$id/_renew",
+        return $this->sendRequest(
+            $this->domainrobotConfig->getUrl() . "/certificate/$id/_renew",
             'PUT',
             ["json" => $cert->toArray(true)]
         );
@@ -404,7 +407,7 @@ class CertificateService extends DomainrobotService
      * make sure the csr has the right format
      *
      * @param Certificate $body
-     * @return
+     * @return void
      */
     private function prepareCsr(Certificate $body)
     {

--- a/src/Service/ContactService.php
+++ b/src/Service/ContactService.php
@@ -47,7 +47,7 @@ class ContactService extends DomainrobotService
     public function createAsync(Contact $body)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/contact",
+            $this->domainrobotConfig->getUrl() . "/contact",
             'POST',
             ["json" => $body->toArray(true)]
         );
@@ -56,7 +56,7 @@ class ContactService extends DomainrobotService
     /**
      * Sends a contact list request.
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return Contact[]
      */
     public function list(Query $body = null)
@@ -77,7 +77,7 @@ class ContactService extends DomainrobotService
     /**
      * Sends a contact list request.
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return DomainrobotPromise
      */
     public function listAsync(Query $body = null)
@@ -87,7 +87,7 @@ class ContactService extends DomainrobotService
             $data = $body->toArray(true);
         }
         return new DomainrobotPromise($this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/contact/_search",
+            $this->domainrobotConfig->getUrl() . "/contact/_search",
             'POST',
             ["json" => $data]
         ));
@@ -96,7 +96,7 @@ class ContactService extends DomainrobotService
     /**
      * Sends a contact info request.
      *
-     * @param [int] $id
+     * @param int $id
      * @return Contact
      */
     public function info($id)
@@ -111,13 +111,13 @@ class ContactService extends DomainrobotService
     /**
      * Sends a contact info request.
      *
-     * @param [int] $id
+     * @param int $id
      * @return DomainrobotPromise
      */
     public function infoAsync($id)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/contact/$id",
+            $this->domainrobotConfig->getUrl() . "/contact/$id",
             'GET'
         );
     }
@@ -125,8 +125,8 @@ class ContactService extends DomainrobotService
     /**
      * Sends a contact delete request.
      *
-     * @param [int] $id
-     * @return
+     * @param int $id
+     * @return void
      */
     public function delete($id)
     {
@@ -140,13 +140,13 @@ class ContactService extends DomainrobotService
     /**
      * Sends a contact delete request.
      *
-     * @param [int] $id
-     * @return
+     * @param int $id
+     * @return DomainrobotPromise
      */
     public function deleteAsync($id)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/contact/$id",
+            $this->domainrobotConfig->getUrl() . "/contact/$id",
             'DELETE'
         );
     }
@@ -176,10 +176,10 @@ class ContactService extends DomainrobotService
     public function updateAsync(Contact $body)
     {
         if ($body->getId() === null) {
-            throw InvalidArgumentException("Field Contact.id is missing.");
+            throw new \InvalidArgumentException("Field Contact.id is missing.");
         }
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/contact/".$body->getId(),
+            $this->domainrobotConfig->getUrl() . "/contact/".$body->getId(),
             'PUT',
             ["json" => $body->toArray(true)]
         );

--- a/src/Service/DomainCancelationService.php
+++ b/src/Service/DomainCancelationService.php
@@ -47,10 +47,10 @@ class DomainCancelationService extends DomainrobotService
     public function createAsync(DomainCancelation $body)
     {
         if ($body->getDomain() === null) {
-            throw InvalidArgumentException("Field DomainCancelation.domain is missing.");
+            throw new \InvalidArgumentException("Field DomainCancelation.domain is missing.");
         }
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/".$body->getDomain()."/cancelation",
+            $this->domainrobotConfig->getUrl() . "/domain/".$body->getDomain()."/cancelation",
             'POST',
             ["json" => $body->toArray(true)]
         );
@@ -64,7 +64,7 @@ class DomainCancelationService extends DomainrobotService
      */
     public function update(DomainCancelation $body)
     {
-        $domainrobotPromise = $this->updateAsync($name);
+        $domainrobotPromise = $this->updateAsync($body);
         $domainrobotResult = $domainrobotPromise->wait();
 
         Domainrobot::setLastDomainrobotResult($domainrobotResult);
@@ -81,10 +81,10 @@ class DomainCancelationService extends DomainrobotService
     public function updateAsync(DomainCancelation $body)
     {
         if ($body->getDomain() === null) {
-            throw InvalidArgumentException("Field DomainCancelation.domain is missing.");
+            throw new \InvalidArgumentException("Field DomainCancelation.domain is missing.");
         }
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/".$body->getDomain()."/cancelation",
+            $this->domainrobotConfig->getUrl() . "/domain/".$body->getDomain()."/cancelation",
             'PUT',
             ["json" => $body->toArray(true)]
         );
@@ -93,8 +93,8 @@ class DomainCancelationService extends DomainrobotService
     /**
      * Deletes an existing cancelation for the given domain.
      *
-     * @param [string] $domain
-     * @return
+     * @param string $domain
+     * @return void
      */
     public function delete($domain)
     {
@@ -108,13 +108,13 @@ class DomainCancelationService extends DomainrobotService
     /**
      * Deletes an existing cancelation for the given domain.
      *
-     * @param [string] $domain
-     * @return
+     * @param string $domain
+     * @return DomainrobotPromise
      */
     public function deleteAsync($domain)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/$domain/cancelation",
+            $this->domainrobotConfig->getUrl() . "/domain/$domain/cancelation",
             'DELETE'
         );
     }
@@ -123,7 +123,7 @@ class DomainCancelationService extends DomainrobotService
     /**
      * Fetches the cancelation for the given domain.
      *
-     * @param [string] $domain
+     * @param string $domain
      * @return DomainCancelation
      */
     public function info($domain)
@@ -138,13 +138,13 @@ class DomainCancelationService extends DomainrobotService
     /**
      * Fetches the cancelation for the given domain.
      *
-     * @param [string] $domain
+     * @param string $domain
      * @return DomainrobotPromise
      */
     public function infoAsync($domain)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/$domain/cancelation",
+            $this->domainrobotConfig->getUrl() . "/domain/$domain/cancelation",
             'GET'
         );
     }
@@ -167,7 +167,7 @@ class DomainCancelationService extends DomainrobotService
      * * gainingRegistrar
      * * updated
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return DomainCancelation[]
      */
     public function list(Query $body = null)
@@ -203,7 +203,7 @@ class DomainCancelationService extends DomainrobotService
      * * gainingRegistrar
      * * updated
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return DomainrobotPromise
      */
 
@@ -214,7 +214,7 @@ class DomainCancelationService extends DomainrobotService
             $data = $body->toArray(true);
         }
         return new DomainrobotPromise($this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/cancelation/_search",
+            $this->domainrobotConfig->getUrl() . "/domain/cancelation/_search",
             'POST',
             ["json" => $data]
         ));

--- a/src/Service/DomainService.php
+++ b/src/Service/DomainService.php
@@ -51,7 +51,7 @@ class DomainService extends DomainrobotService
     public function createAsync(Domain $body)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain",
+            $this->domainrobotConfig->getUrl() . "/domain",
             'POST',
             ["json" => $body->toArray(true)]
         );
@@ -60,8 +60,8 @@ class DomainService extends DomainrobotService
     /**
      * Sends a authinfo1 create request.
      *
-     * @param [string] $name
-     * @return
+     * @param string $name
+     * @return Domain
      */
     public function createAuthinfo1($name)
     {
@@ -76,13 +76,13 @@ class DomainService extends DomainrobotService
     /**
      * Sends a authinfo1 create request.
      *
-     * @param [string] $name
+     * @param string $name
      * @return DomainrobotPromise
      */
     public function createAuthinfo1Async($name)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/$name/_authinfo1",
+            $this->domainrobotConfig->getUrl() . "/domain/$name/_authinfo1",
             'POST'
         );
     }
@@ -90,8 +90,8 @@ class DomainService extends DomainrobotService
     /**
      * Sends a authinfo2 create request.
      *
-     * @param [string] $name
-     * @return
+     * @param string $name
+     * @return void
      */
     public function createAuthinfo2($name)
     {
@@ -102,13 +102,13 @@ class DomainService extends DomainrobotService
     /**
      * Sends a authinfo2 create request.
      *
-     * @param [string] $name
-     * @return
+     * @param string $name
+     * @return DomainrobotPromise
      */
     public function createAuthinfo2Async($name)
     {
-        $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/$name/_authinfo2",
+        return $this->sendRequest(
+            $this->domainrobotConfig->getUrl() . "/domain/$name/_authinfo2",
             'POST'
         );
     }
@@ -140,10 +140,10 @@ class DomainService extends DomainrobotService
     public function renewAsync(Domain $body)
     {
         if ($body->getName() === null) {
-            throw InvalidArgumentException("Field Domain.name is missing.");
+            throw new \InvalidArgumentException("Field Domain.name is missing.");
         }
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/".$body->getName()."/_renew",
+            $this->domainrobotConfig->getUrl() . "/domain/".$body->getName()."/_renew",
             'PUT',
             ["json" => $body->toArray(true)]
         );
@@ -176,7 +176,7 @@ class DomainService extends DomainrobotService
     public function transferAsync(Domain $body)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/_transfer",
+            $this->domainrobotConfig->getUrl() . "/domain/_transfer",
             'POST',
             ["json" => $body->toArray(true)]
         );
@@ -187,11 +187,11 @@ class DomainService extends DomainrobotService
      * Update the registry status for an existing domain.
      *
      * @param Domain $body
-     * @return
+     * @return void
      */
     public function updateStatus(Domain $body)
     {
-        $domainrobotPromise = $this->updateStatusAsync($name);
+        $domainrobotPromise = $this->updateStatusAsync($body);
         $domainrobotPromise->wait();
     }
 
@@ -199,15 +199,16 @@ class DomainService extends DomainrobotService
      * Update the registry status for an existing domain.
      *
      * @param Domain $body
-     * @return
+     * @return DomainrobotPromise
      */
     public function updateStatusAsync(Domain $body)
     {
         if ($body->getName() === null) {
-            throw InvalidArgumentException("Field Domain.name is missing.");
+            throw new \InvalidArgumentException("Field Domain.name is missing.");
         }
-        $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/".$body->getName()."/_statusUpdate",
+
+        return $this->sendRequest(
+            $this->domainrobotConfig->getUrl() . "/domain/".$body->getName()."/_statusUpdate",
             'PUT',
             ["json" => $body->toArray(true)]
         );
@@ -237,7 +238,7 @@ class DomainService extends DomainrobotService
      * * created
      * * autorenew
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return Domain[]
      */
     public function list(Query $body = null)
@@ -279,7 +280,7 @@ class DomainService extends DomainrobotService
      * * created
      * * autorenew
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return DomainrobotPromise
      */
     public function listAsync(Query $body = null)
@@ -289,7 +290,7 @@ class DomainService extends DomainrobotService
             $data = $body->toArray(true);
         }
         return new DomainrobotPromise($this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/_search",
+            $this->domainrobotConfig->getUrl() . "/domain/_search",
             'POST',
             ["json" => $data]
         ));
@@ -328,7 +329,7 @@ class DomainService extends DomainrobotService
      * * authinfo
      * * status
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return DomainRestore[]
      */
     public function restoreList(Query $body = null)
@@ -342,7 +343,7 @@ class DomainService extends DomainrobotService
         $domainRestores = array();
         foreach ($data as $d) {
             $dr = new DomainRestore($d);
-            array_push($domains, $dr);
+            array_push($domainRestores, $dr);
         }
         return $domainRestores;
     }
@@ -380,7 +381,7 @@ class DomainService extends DomainrobotService
      * * authinfo
      * * status
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return DomainrobotPromise
      */
     public function restoreListAsync(Query $body = null)
@@ -390,7 +391,7 @@ class DomainService extends DomainrobotService
             $data = $body->toArray(true);
         }
         return new DomainrobotPromise($this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/restore/_search",
+            $this->domainrobotConfig->getUrl() . "/domain/restore/_search",
             'POST',
             ["json" => $data]
         ));
@@ -399,7 +400,7 @@ class DomainService extends DomainrobotService
     /**
      * Sends a Domain info request.
      *
-     * @param [string] $name
+     * @param string $name
      * @return Domain
      */
     public function info($name)
@@ -413,13 +414,13 @@ class DomainService extends DomainrobotService
     /**
      * Sends a Domain info request.
      *
-     * @param [string] $name
+     * @param string $name
      * @return DomainrobotPromise
      */
     public function infoAsync($name)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/$name",
+            $this->domainrobotConfig->getUrl() . "/domain/$name",
             'GET'
         );
     }
@@ -427,8 +428,8 @@ class DomainService extends DomainrobotService
     /**
      * Sends a authinfo1 delete request.
      *
-     * @param [string] $name
-     * @return
+     * @param string $name
+     * @return void
      */
     public function deleteAuthinfo1($name)
     {
@@ -439,13 +440,13 @@ class DomainService extends DomainrobotService
     /**
      * Sends a authinfo1 delete request.
      *
-     * @param [string] $name
-     * @return
+     * @param string $name
+     * @return DomainrobotPromise
      */
     public function deleteAuthinfo1Async($name)
     {
-        $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/$name/_authinfo1",
+        return $this->sendRequest(
+            $this->domainrobotConfig->getUrl() . "/domain/$name/_authinfo1",
             'DELETE'
         );
     }
@@ -454,7 +455,7 @@ class DomainService extends DomainrobotService
      * Sends a Domain update request.
      *
      * @param Domain $body
-     * @return ObjektJob
+     * @return ObjectJob
      */
     public function update(Domain $body)
     {
@@ -477,10 +478,10 @@ class DomainService extends DomainrobotService
     public function updateAsync(Domain $body)
     {
         if ($body->getName() === null) {
-            throw InvalidArgumentException("Field Domain.name is missing.");
+            throw new \InvalidArgumentException("Field Domain.name is missing.");
         }
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/".$body->getName(),
+            $this->domainrobotConfig->getUrl() . "/domain/".$body->getName(),
             'PUT',
             ["json" => $body->toArray(true)]
         );
@@ -513,10 +514,10 @@ class DomainService extends DomainrobotService
     public function restoreAsync(DomainRestore $body)
     {
         if ($body->getName() === null) {
-            throw InvalidArgumentException("Field DomainRestore.name is missing.");
+            throw new \InvalidArgumentException("Field DomainRestore.name is missing.");
         }
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/domain/".$body->getName()."/_restore",
+            $this->domainrobotConfig->getUrl() . "/domain/".$body->getName()."/_restore",
             'PUT',
             ["json" => $body->toArray(true)]
         );

--- a/src/Service/DomainStudioService.php
+++ b/src/Service/DomainStudioService.php
@@ -78,7 +78,7 @@ class DomainStudioService extends DomainrobotService
     public function searchAsync(DomainEnvelopeSearchRequest $body)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl()."/domainstudio",
+            $this->domainrobotConfig->getUrl()."/domainstudio",
             "POST",
             ["json" => $body->toArray(true)]
         );

--- a/src/Service/DomainrobotService.php
+++ b/src/Service/DomainrobotService.php
@@ -34,7 +34,7 @@ class DomainrobotService
 
     public function __construct(DomainrobotConfig $domainrobotConfig)
     {
-        $this->domainRobotConfig = $domainrobotConfig;
+        $this->domainrobotConfig = $domainrobotConfig;
 
         // get current version of the SDK
         $handle = fopen(__DIR__."/../../composer.json", "r");
@@ -46,11 +46,11 @@ class DomainrobotService
             'headers' => [
                 DomainrobotHeaders::DOMAINROBOT_CONTENT_TYPE => "application/json",
                 DomainrobotHeaders::DOMAINROBOT_USER_AGENT => "PHPDomainrobotSdk/$matches[1]",
-                DomainrobotHeaders::DOMAINROBOT_HEADER_CONTEXT => $this->domainRobotConfig->getAuth()->getContext()
+                DomainrobotHeaders::DOMAINROBOT_HEADER_CONTEXT => $this->domainrobotConfig->getAuth()->getContext()
             ],
             'auth' => [
-                $this->domainRobotConfig->getAuth()->getUser(),
-                $this->domainRobotConfig->getAuth()->getPassword()
+                $this->domainrobotConfig->getAuth()->getUser(),
+                $this->domainrobotConfig->getAuth()->getPassword()
             ]
         ];
     }
@@ -82,7 +82,6 @@ class DomainrobotService
      *
      * @return DomainrobotPromise
      */
-
     public function sendRequest($url, $method, $options = [])
     {
         $guzzleClient = new Client($this->guzzleClientConfig);

--- a/src/Service/PollMessageService.php
+++ b/src/Service/PollMessageService.php
@@ -5,8 +5,8 @@ namespace Domainrobot\Service;
 use Domainrobot\Domainrobot;
 use Domainrobot\Lib\ArrayHelper;
 use Domainrobot\Lib\DomainrobotConfig;
+use Domainrobot\Lib\DomainrobotPromise;
 use Domainrobot\Model\PollMessage;
-use Domainrobot\Model\DomainrobotPromise;
 use Domainrobot\Service\DomainrobotService;
 
 class PollMessageService extends DomainrobotService
@@ -45,12 +45,12 @@ class PollMessageService extends DomainrobotService
      * The poll system works according to the "First In First Out (FIFO)" principle.
      * More information at https://help.internetx.com/display/APIPROCESSEN/Asynchronous+Notifications#AsynchronousNotifications-Polling
      *
-     * @return GuzzleHttp\Promise\PromiseInterface $promise
+     * @return DomainrobotPromise
      */
     public function infoAsync()
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/poll",
+            $this->domainrobotConfig->getUrl() . "/poll",
             'GET'
         );
     }
@@ -59,8 +59,8 @@ class PollMessageService extends DomainrobotService
     /**
      * Confirms the PollMessage with the given id.
      *
-     * @param [int] $id
-     * @return
+     * @param int $id
+     * @return void
      */
     public function confirm($id)
     {
@@ -73,13 +73,13 @@ class PollMessageService extends DomainrobotService
     /**
      * Confirms the PollMessage with the given id.
      *
-     * @param [int] $id
+     * @param int $id
      * @return DomainrobotPromise
      */
     public function confirmAsync($id)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/poll/$id",
+            $this->domainrobotConfig->getUrl() . "/poll/$id",
             'PUT'
         );
     }

--- a/src/Service/SslContactService.php
+++ b/src/Service/SslContactService.php
@@ -47,7 +47,7 @@ class SslContactService extends DomainrobotService
     public function createAsync(SslContact $body)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/sslcontacct",
+            $this->domainrobotConfig->getUrl() . "/sslcontacct",
             'POST',
             ["json" => $body->toArray(true)]
         );
@@ -56,7 +56,7 @@ class SslContactService extends DomainrobotService
     /**
      * Sends a sslcontact list request.
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return SslContact[]
      */
     public function list(Query $body = null)
@@ -77,7 +77,7 @@ class SslContactService extends DomainrobotService
     /**
      * Sends a sslcontact list request.
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return DomainrobotPromise
      */
     public function listAsync(Query $body = null)
@@ -87,7 +87,7 @@ class SslContactService extends DomainrobotService
             $data = $body->toArray(true);
         }
         return new DomainrobotPromise($this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/sslcontact/_search",
+            $this->domainrobotConfig->getUrl() . "/sslcontact/_search",
             'POST',
             ["json" => $data]
         ));
@@ -96,7 +96,7 @@ class SslContactService extends DomainrobotService
     /**
      * Sends a sslcontact info request.
      *
-     * @param [int] $id
+     * @param int $id
      * @return SslContact
      */
     public function info($id)
@@ -110,13 +110,13 @@ class SslContactService extends DomainrobotService
     /**
      * Sends a sslcontact info request.
      *
-     * @param [int] $id
+     * @param int $id
      * @return DomainrobotPromise
      */
     public function infoAsync($id)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/sslcontact/$id",
+            $this->domainrobotConfig->getUrl() . "/sslcontact/$id",
             'GET'
         );
     }
@@ -124,8 +124,8 @@ class SslContactService extends DomainrobotService
     /**
      * Sends a sslcontact delete request.
      *
-     * @param [int] $id
-     * @return SslContact
+     * @param int $id
+     * @return void
      */
     public function delete($id)
     {
@@ -138,13 +138,13 @@ class SslContactService extends DomainrobotService
     /**
      * Sends a sslcontact delete request.
      *
-     * @param [int] $id
+     * @param int $id
      * @return DomainrobotPromise
      */
     public function deleteAsync($id)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/sslcontact/$id",
+            $this->domainrobotConfig->getUrl() . "/sslcontact/$id",
             'DELETE'
         );
     }
@@ -174,10 +174,10 @@ class SslContactService extends DomainrobotService
     public function updateAsync(SslContact $body)
     {
         if ($body->getId() === null) {
-            throw InvalidArgumentException("Field SslContact.id is missing.");
+            throw new \InvalidArgumentException("Field SslContact.id is missing.");
         }
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl()."/sslcontact/".$body->getId(),
+            $this->domainrobotConfig->getUrl()."/sslcontact/".$body->getId(),
             'PUT',
             ["json" => $body->toArray(true)]
         );

--- a/src/Service/TransferOutService.php
+++ b/src/Service/TransferOutService.php
@@ -7,7 +7,6 @@ use Domainrobot\Lib\ArrayHelper;
 use Domainrobot\Lib\DomainrobotConfig;
 use Domainrobot\Lib\DomainrobotPromise;
 use Domainrobot\Model\Query;
-use Domainrobot\Model\DomainCancelation;
 use Domainrobot\Model\TransferAnswer;
 use Domainrobot\Model\TransferOut;
 use Domainrobot\Service\DomainrobotService;
@@ -27,8 +26,8 @@ class TransferOutService extends DomainrobotService
     /**
      * Answer a transfer for the given domain with the given answer.
      *
-     * @param [string] $domain
-     * @param [string] $type
+     * @param string $domain
+     * @param string $answer
      * @return TransferOut
      */
     public function answer($domain, $answer)
@@ -44,8 +43,8 @@ class TransferOutService extends DomainrobotService
     /**
      * Answer a transfer for the given domain with the given answer.
      *
-     * @param [string] $domain,
-     * @param [string] $answer
+     * @param string $domain,
+     * @param string $answer
      * @return DomainrobotPromise
      */
     public function answerAsync($domain, $answer)
@@ -58,7 +57,7 @@ class TransferOutService extends DomainrobotService
         }
 
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/transferout/$domain/$transformedAnswer",
+            $this->domainrobotConfig->getUrl() . "/transferout/$domain/$transformedAnswer",
             'PUT'
         );
     }
@@ -84,7 +83,7 @@ class TransferOutService extends DomainrobotService
      * * transaction
      * * status
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return TransferOut[]
      */
     public function list(Query $body = null)
@@ -123,7 +122,7 @@ class TransferOutService extends DomainrobotService
      * * transaction
      * * status
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return DomainrobotPromise
      */
     public function listAsync(Query $body = null)
@@ -133,7 +132,7 @@ class TransferOutService extends DomainrobotService
             $data = $body->toArray(true);
         }
         return new DomainrobotPromise($this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/transferout/_search",
+            $this->domainrobotConfig->getUrl() . "/transferout/_search",
             'POST',
             ["json" => $data]
         ));

--- a/src/Service/TrustedApplicationService.php
+++ b/src/Service/TrustedApplicationService.php
@@ -48,7 +48,7 @@ class TrustedApplicationService extends DomainrobotService
     public function createAsync(TrustedApplication $body)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/trustedapp",
+            $this->domainrobotConfig->getUrl() . "/trustedapp",
             'POST',
             ["json" => $body->toArray(true)]
         );
@@ -86,7 +86,7 @@ class TrustedApplicationService extends DomainrobotService
             $body = $query->toArray(true);
         }
         return new DomainrobotPromise($this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/trustedapp/_search",
+            $this->domainrobotConfig->getUrl() . "/trustedapp/_search",
             'POST',
             ["json" => $body]
         ));
@@ -95,7 +95,7 @@ class TrustedApplicationService extends DomainrobotService
     /**
      * Sends a TrustedApplication info request.
      *
-     * @param [int] $id
+     * @param int $id
      * @return TrustedApplication
      */
     public function info($id)
@@ -110,13 +110,13 @@ class TrustedApplicationService extends DomainrobotService
     /**
      * Sends a TrustedApplication info request.
      *
-     * @param [int] $id
+     * @param int $id
      * @return DomainrobotPromise
      */
     public function infoAsync($id)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/trustedapp/$id",
+            $this->domainrobotConfig->getUrl() . "/trustedapp/$id",
             'GET'
         );
     }
@@ -124,8 +124,8 @@ class TrustedApplicationService extends DomainrobotService
     /**
      * Sends a TrustedApplication delete request.
      *
-     * @param [int] $id
-     * @return
+     * @param int $id
+     * @return void
      */
     public function delete($id)
     {
@@ -139,13 +139,13 @@ class TrustedApplicationService extends DomainrobotService
     /**
      * Sends a TrustedApplication delete request.
      *
-     * @param [int] $id
+     * @param int $id
      * @return DomainrobotPromise
      */
     public function deleteAsync($id)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/trustedapp/$id",
+            $this->domainrobotConfig->getUrl() . "/trustedapp/$id",
             'DELETE'
         );
     }
@@ -154,7 +154,7 @@ class TrustedApplicationService extends DomainrobotService
      * Sends a TrustedApplication update request.
      *
      * @param TrustedApplication $body
-     * @return TrustedApplication
+     * @return void
      */
     public function update(TrustedApplication $body)
     {
@@ -172,13 +172,13 @@ class TrustedApplicationService extends DomainrobotService
      */
     public function updateAsync(TrustedApplication $body)
     {
-        if ($body->getId() === null) {
-            throw InvalidArgumentException("Field TrustedApplication.id is missing.");
+        if ($body->getUuId() === null) {
+            throw new \InvalidArgumentException("Field TrustedApplication.id is missing.");
         }
-        $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/trustedapp/".$body->getId(),
+        return $this->sendRequest(
+            $this->domainrobotConfig->getUrl() . "/trustedapp/".$body->getUuId(),
             'PUT',
-            ["json" => $this->trustedApplicationModel->toArray(true)]
+            ["json" => $body->toArray(true)]
         );
     }
 }

--- a/src/Service/ZoneService.php
+++ b/src/Service/ZoneService.php
@@ -48,7 +48,7 @@ class ZoneService extends DomainrobotService
     public function createAsync(Zone $body)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/zone",
+            $this->domainrobotConfig->getUrl() . "/zone",
             'POST',
             ["json" => $body->toArray(true)]
         );
@@ -58,7 +58,7 @@ class ZoneService extends DomainrobotService
      * Sends a zone stream request to add and/or remove records for every zone with
      * the given origin.
      *
-     * @param [string] $origin
+     * @param string $origin
      * @param ZoneStream $body
      */
     public function stream($origin, ZoneStream $body)
@@ -75,14 +75,14 @@ class ZoneService extends DomainrobotService
      * Sends a zone stream request to add and/or remove records for every zone with
      * the given origin.
      *
-     * @param [string] $origin
+     * @param string $origin
      * @param ZoneStream $body
      * @return DomainrobotPromise
      */
     public function streamAsync($origin, ZoneStream $body)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/zone/$origin/_stream",
+            $this->domainrobotConfig->getUrl() . "/zone/$origin/_stream",
             'POST',
             ["json" => $body->toArray(true)]
         );
@@ -116,7 +116,7 @@ class ZoneService extends DomainrobotService
         $systemNameServer = $body->getVirtualNameServer();
 
         return new DomainrobotPromise($this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/zone/$name/$systemNameServer/_import",
+            $this->domainrobotConfig->getUrl() . "/zone/$name/$systemNameServer/_import",
             'POST',
             ["json" => $body->toArray(true)]
         ));
@@ -147,7 +147,7 @@ class ZoneService extends DomainrobotService
      * * primary
      * * changed
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return Zone[]
      */
     public function list(Query $body = null)
@@ -190,7 +190,7 @@ class ZoneService extends DomainrobotService
      * * primary
      * * changed
      *
-     * @param Query $body
+     * @param Query|null $body
      * @return DomainrobotPromise
      */
     public function listAsync(Query $body = null)
@@ -200,7 +200,7 @@ class ZoneService extends DomainrobotService
             $data = $body->toArray(true);
         }
         return new DomainrobotPromise($this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/zone/_search",
+            $this->domainrobotConfig->getUrl() . "/zone/_search",
             'POST',
             ["json" => $data]
         ));
@@ -209,8 +209,8 @@ class ZoneService extends DomainrobotService
     /**
      * Sends a zone info request.
      *
-     * @param [string] $name
-     * @param [string] $systemNameServer
+     * @param string $name
+     * @param string $systemNameServer
      * @return Zone
      */
     public function info($name, $systemNameServer)
@@ -224,14 +224,14 @@ class ZoneService extends DomainrobotService
     /**
      * Sends a zone info request.
      *
-     * @param [string] $name
-     * @param [string] $systemNameServer
+     * @param string $name
+     * @param string $systemNameServer
      * @return DomainrobotPromise
      */
     public function infoAsync($name, $systemNameServer)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/zone/$name/$systemNameServer",
+            $this->domainrobotConfig->getUrl() . "/zone/$name/$systemNameServer",
             'GET'
         );
     }
@@ -239,9 +239,9 @@ class ZoneService extends DomainrobotService
     /**
      * Sends a zone delete request.
      *
-     * @param [string] $name
-     * @param [string] $systemNameServer
-     * @return
+     * @param string $name
+     * @param string $systemNameServer
+     * @return void
      */
     public function delete($name, $systemNameServer)
     {
@@ -249,20 +249,19 @@ class ZoneService extends DomainrobotService
         $domainrobotResult = $domainrobotPromise->wait();
 
         Domainrobot::setLastDomainrobotResult($domainrobotResult);
-
     }
 
     /**
      * Sends a zone delete request.
      *
-     * @param [string] $name
-     * @param [string] $systemNameServer
-     * @return
+     * @param string $name
+     * @param string $systemNameServer
+     * @return DomainrobotPromise
      */
     public function deleteAsync($name, $systemNameServer)
     {
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/zone/$name/$systemNameServer",
+            $this->domainrobotConfig->getUrl() . "/zone/$name/$systemNameServer",
             'DELETE'
         );
     }
@@ -287,22 +286,22 @@ class ZoneService extends DomainrobotService
      * Sends a zone update request.
      *
      * @param Zone $body
-     * @return GuzzleHttp\Promise\PromiseInterface $promise
+     * @return DomainrobotPromise
      */
     public function updateAsync(Zone $body)
     {
         if ($body->getOrigin() === null) {
-            throw InvalidArgumentException("Field Zone.origin is missing.");
+            throw new \InvalidArgumentException("Field Zone.origin is missing.");
         } else {
             $name = $body->getOrigin();
         }
         if ($body->getVirtualNameServer() === null) {
-            throw InvalidArgumentException("Field Zone.virtualNameServer is missing.");
+            throw new \InvalidArgumentException("Field Zone.virtualNameServer is missing.");
         } else {
             $systemNameServer = $body->getVirtualNameServer();
         }
         return $this->sendRequest(
-            $this->domainRobotConfig->getUrl() . "/zone/$name/$systemNameServer",
+            $this->domainrobotConfig->getUrl() . "/zone/$name/$systemNameServer",
             'PUT',
             ["json" => $body->toArray(true)]
         );


### PR DESCRIPTION
In the company I work for we are using this PHP SDK library in order to integrate our system with InterNetX platform.

While working with the different services provided in this SDK, I've noticed that there are some issues reported by Phan (PHP static analyzer) at the time of using some of them. After examining the issues, I was able to verify most of them, and noticed that the **severity goes from low to high/important**.

### With this PR the following changes are introduced:

1. Instances of `domainRobotConfig` properties were renamed to `domainrobotConfig` as was intended by one of the previous PRs merged into master.
2. References to undeclared variables were fixed (e.g. in `src/Service/CertificateService.php`, `src/Service/TrustedApplicationService.php`)
3. Instances where no return value was being returned in contexts where a `DomainrobotPromise` was expected were added
4. Overall annotations blocks were corrected according to the accepted PHP standard (PHPDoc, Phan annotations, etc.)
5. Instances where `InvalidArgumentException()`s were intended to be thrown, but invocation resulted in errors due to being called as methods instead of instantiations were fixed.
6. A nonexistent method invocation (`->getId()`) fixed in a case where a `TrustedApplication` object was provided as argument. In this case, the correct method to be called would be `->getUuId()`

### HOW TO TEST

If you have automated testing mechanisms for this SDK, they should work just fine. The cases where some conditions would lead to fatal errors (like invocation of nonexistent methods, or throwing exceptions as if they were method callings) should also work.

Running Phan against the `src/Service` should not yield any critical error.

Feel free to contact me in case of any question or doubt.