### PR TITLE
Fixed Bug in last Commit: toArray() retrieveAllValues allow FALSE and empty Strings

### DIFF
--- a/src/Model/Account.php
+++ b/src/Model/Account.php
@@ -628,7 +628,12 @@ class Account implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/AddressClaim.php
+++ b/src/Model/AddressClaim.php
@@ -505,7 +505,12 @@ class AddressClaim implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/AlexaSiteInfo.php
+++ b/src/Model/AlexaSiteInfo.php
@@ -565,7 +565,12 @@ class AlexaSiteInfo implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/AlexaSiteInfoHighestRankedIncountry.php
+++ b/src/Model/AlexaSiteInfoHighestRankedIncountry.php
@@ -415,7 +415,12 @@ class AlexaSiteInfoHighestRankedIncountry implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/AlexaSiteInfoPageViewsPerDay.php
+++ b/src/Model/AlexaSiteInfoPageViewsPerDay.php
@@ -385,7 +385,12 @@ class AlexaSiteInfoPageViewsPerDay implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/AlexaSiteInfoSiteData.php
+++ b/src/Model/AlexaSiteInfoSiteData.php
@@ -415,7 +415,12 @@ class AlexaSiteInfoSiteData implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiAlexaSiteInfoResponse.php
+++ b/src/Model/ApiAlexaSiteInfoResponse.php
@@ -415,7 +415,12 @@ class ApiAlexaSiteInfoResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiDomainStudioResponse.php
+++ b/src/Model/ApiDomainStudioResponse.php
@@ -415,7 +415,12 @@ class ApiDomainStudioResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiEstimationErrorResponse.php
+++ b/src/Model/ApiEstimationErrorResponse.php
@@ -415,7 +415,12 @@ class ApiEstimationErrorResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiEstimationResponse.php
+++ b/src/Model/ApiEstimationResponse.php
@@ -415,7 +415,12 @@ class ApiEstimationResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiExchangeRateResponse.php
+++ b/src/Model/ApiExchangeRateResponse.php
@@ -415,7 +415,12 @@ class ApiExchangeRateResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiHistoryUserResponse.php
+++ b/src/Model/ApiHistoryUserResponse.php
@@ -415,7 +415,12 @@ class ApiHistoryUserResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiKeywordResponse.php
+++ b/src/Model/ApiKeywordResponse.php
@@ -415,7 +415,12 @@ class ApiKeywordResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiMajesticResponse.php
+++ b/src/Model/ApiMajesticResponse.php
@@ -415,7 +415,12 @@ class ApiMajesticResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiMetaResponse.php
+++ b/src/Model/ApiMetaResponse.php
@@ -415,7 +415,12 @@ class ApiMetaResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiResponseMessages.php
+++ b/src/Model/ApiResponseMessages.php
@@ -415,7 +415,12 @@ class ApiResponseMessages implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiResponseObject.php
+++ b/src/Model/ApiResponseObject.php
@@ -385,7 +385,12 @@ class ApiResponseObject implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiSistrixResponse.php
+++ b/src/Model/ApiSistrixResponse.php
@@ -415,7 +415,12 @@ class ApiSistrixResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiSocialMediaResponse.php
+++ b/src/Model/ApiSocialMediaResponse.php
@@ -415,7 +415,12 @@ class ApiSocialMediaResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiStatisticsResponse.php
+++ b/src/Model/ApiStatisticsResponse.php
@@ -415,7 +415,12 @@ class ApiStatisticsResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiUserStatisticsResponse.php
+++ b/src/Model/ApiUserStatisticsResponse.php
@@ -415,7 +415,12 @@ class ApiUserStatisticsResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiV1EstimationResponse.php
+++ b/src/Model/ApiV1EstimationResponse.php
@@ -415,7 +415,12 @@ class ApiV1EstimationResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ApiWaybackResponse.php
+++ b/src/Model/ApiWaybackResponse.php
@@ -415,7 +415,12 @@ class ApiWaybackResponse implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Application.php
+++ b/src/Model/Application.php
@@ -448,7 +448,12 @@ class Application implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BackupMx.php
+++ b/src/Model/BackupMx.php
@@ -508,7 +508,12 @@ class BackupMx implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BasicCustomer.php
+++ b/src/Model/BasicCustomer.php
@@ -1324,7 +1324,12 @@ class BasicCustomer implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BasicDocument.php
+++ b/src/Model/BasicDocument.php
@@ -748,7 +748,12 @@ class BasicDocument implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BasicUser.php
+++ b/src/Model/BasicUser.php
@@ -400,7 +400,12 @@ class BasicUser implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BillingObjectLimit.php
+++ b/src/Model/BillingObjectLimit.php
@@ -535,7 +535,12 @@ class BillingObjectLimit implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkBackupMxDeleteRequest.php
+++ b/src/Model/BulkBackupMxDeleteRequest.php
@@ -385,7 +385,12 @@ class BulkBackupMxDeleteRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkBackupMxPostRequest.php
+++ b/src/Model/BulkBackupMxPostRequest.php
@@ -385,7 +385,12 @@ class BulkBackupMxPostRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkDomainCancelationDeleteRequest.php
+++ b/src/Model/BulkDomainCancelationDeleteRequest.php
@@ -385,7 +385,12 @@ class BulkDomainCancelationDeleteRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkDomainCancelationPatchRequest.php
+++ b/src/Model/BulkDomainCancelationPatchRequest.php
@@ -415,7 +415,12 @@ class BulkDomainCancelationPatchRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkDomainCancelationPostRequest.php
+++ b/src/Model/BulkDomainCancelationPostRequest.php
@@ -385,7 +385,12 @@ class BulkDomainCancelationPostRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkDomainCommentRequest.php
+++ b/src/Model/BulkDomainCommentRequest.php
@@ -415,7 +415,12 @@ class BulkDomainCommentRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkDomainDeleteRequest.php
+++ b/src/Model/BulkDomainDeleteRequest.php
@@ -385,7 +385,12 @@ class BulkDomainDeleteRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkDomainPatchRequest.php
+++ b/src/Model/BulkDomainPatchRequest.php
@@ -445,7 +445,12 @@ class BulkDomainPatchRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkDomainPostRequest.php
+++ b/src/Model/BulkDomainPostRequest.php
@@ -385,7 +385,12 @@ class BulkDomainPostRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkDomainPreregDeleteRequest.php
+++ b/src/Model/BulkDomainPreregDeleteRequest.php
@@ -385,7 +385,12 @@ class BulkDomainPreregDeleteRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkDomainPreregPatchRequest.php
+++ b/src/Model/BulkDomainPreregPatchRequest.php
@@ -415,7 +415,12 @@ class BulkDomainPreregPatchRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkDomainPreregPostRequest.php
+++ b/src/Model/BulkDomainPreregPostRequest.php
@@ -385,7 +385,12 @@ class BulkDomainPreregPostRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkDomainSafeDomainRequest.php
+++ b/src/Model/BulkDomainSafeDomainRequest.php
@@ -385,7 +385,12 @@ class BulkDomainSafeDomainRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkMailProxyDeleteRequest.php
+++ b/src/Model/BulkMailProxyDeleteRequest.php
@@ -385,7 +385,12 @@ class BulkMailProxyDeleteRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkMailProxyPatchRequest.php
+++ b/src/Model/BulkMailProxyPatchRequest.php
@@ -415,7 +415,12 @@ class BulkMailProxyPatchRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkMailProxyPostRequest.php
+++ b/src/Model/BulkMailProxyPostRequest.php
@@ -385,7 +385,12 @@ class BulkMailProxyPostRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkObjectUserAssignmentPatchRequest.php
+++ b/src/Model/BulkObjectUserAssignmentPatchRequest.php
@@ -385,7 +385,12 @@ class BulkObjectUserAssignmentPatchRequest implements ModelInterface, ArrayAcces
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkRedirectDeleteRequest.php
+++ b/src/Model/BulkRedirectDeleteRequest.php
@@ -385,7 +385,12 @@ class BulkRedirectDeleteRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkRedirectPatchRequest.php
+++ b/src/Model/BulkRedirectPatchRequest.php
@@ -415,7 +415,12 @@ class BulkRedirectPatchRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkRedirectPostRequest.php
+++ b/src/Model/BulkRedirectPostRequest.php
@@ -385,7 +385,12 @@ class BulkRedirectPostRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkZoneCommentRequest.php
+++ b/src/Model/BulkZoneCommentRequest.php
@@ -415,7 +415,12 @@ class BulkZoneCommentRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkZoneDeleteRequest.php
+++ b/src/Model/BulkZoneDeleteRequest.php
@@ -385,7 +385,12 @@ class BulkZoneDeleteRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkZonePatchRequest.php
+++ b/src/Model/BulkZonePatchRequest.php
@@ -445,7 +445,12 @@ class BulkZonePatchRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/BulkZonePostRequest.php
+++ b/src/Model/BulkZonePostRequest.php
@@ -385,7 +385,12 @@ class BulkZonePostRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/CaCertificate.php
+++ b/src/Model/CaCertificate.php
@@ -445,7 +445,12 @@ class CaCertificate implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Card.php
+++ b/src/Model/Card.php
@@ -505,7 +505,12 @@ class Card implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/CertAuthentication.php
+++ b/src/Model/CertAuthentication.php
@@ -535,7 +535,12 @@ class CertAuthentication implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/CertAuthenticationStatus.php
+++ b/src/Model/CertAuthenticationStatus.php
@@ -385,7 +385,12 @@ class CertAuthenticationStatus implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Certificate.php
+++ b/src/Model/Certificate.php
@@ -1423,7 +1423,12 @@ class Certificate implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/CertificateData.php
+++ b/src/Model/CertificateData.php
@@ -925,7 +925,12 @@ class CertificateData implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/CertificateHistory.php
+++ b/src/Model/CertificateHistory.php
@@ -385,7 +385,12 @@ class CertificateHistory implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Claims.php
+++ b/src/Model/Claims.php
@@ -895,7 +895,12 @@ class Claims implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Configuration.php
+++ b/src/Model/Configuration.php
@@ -330,7 +330,12 @@ class Configuration implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Contact.php
+++ b/src/Model/Contact.php
@@ -1183,7 +1183,12 @@ class Contact implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactAeroExtensions.php
+++ b/src/Model/ContactAeroExtensions.php
@@ -385,7 +385,12 @@ class ContactAeroExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactAuExtensions.php
+++ b/src/Model/ContactAuExtensions.php
@@ -565,7 +565,12 @@ class ContactAuExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactBankExtensions.php
+++ b/src/Model/ContactBankExtensions.php
@@ -355,7 +355,12 @@ class ContactBankExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactBarcelonaExtensions.php
+++ b/src/Model/ContactBarcelonaExtensions.php
@@ -355,7 +355,12 @@ class ContactBarcelonaExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactBirthExtensions.php
+++ b/src/Model/ContactBirthExtensions.php
@@ -445,7 +445,12 @@ class ContactBirthExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactCaExtensions.php
+++ b/src/Model/ContactCaExtensions.php
@@ -475,7 +475,12 @@ class ContactCaExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactCatExtensions.php
+++ b/src/Model/ContactCatExtensions.php
@@ -355,7 +355,12 @@ class ContactCatExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactExtensions.php
+++ b/src/Model/ContactExtensions.php
@@ -925,7 +925,12 @@ class ContactExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactGeneralExtensions.php
+++ b/src/Model/ContactGeneralExtensions.php
@@ -595,7 +595,12 @@ class ContactGeneralExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactHkExtensions.php
+++ b/src/Model/ContactHkExtensions.php
@@ -505,7 +505,12 @@ class ContactHkExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactIdentificationExtensions.php
+++ b/src/Model/ContactIdentificationExtensions.php
@@ -445,7 +445,12 @@ class ContactIdentificationExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactItExtensions.php
+++ b/src/Model/ContactItExtensions.php
@@ -355,7 +355,12 @@ class ContactItExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactJobsExtensions.php
+++ b/src/Model/ContactJobsExtensions.php
@@ -475,7 +475,12 @@ class ContactJobsExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactJpExtensions.php
+++ b/src/Model/ContactJpExtensions.php
@@ -505,7 +505,12 @@ class ContactJpExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactLuxeExtensions.php
+++ b/src/Model/ContactLuxeExtensions.php
@@ -355,7 +355,12 @@ class ContactLuxeExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactMadridExtensions.php
+++ b/src/Model/ContactMadridExtensions.php
@@ -355,7 +355,12 @@ class ContactMadridExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactNzExtensions.php
+++ b/src/Model/ContactNzExtensions.php
@@ -355,7 +355,12 @@ class ContactNzExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactReference.php
+++ b/src/Model/ContactReference.php
@@ -475,7 +475,12 @@ class ContactReference implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactRoExtensions.php
+++ b/src/Model/ContactRoExtensions.php
@@ -355,7 +355,12 @@ class ContactRoExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactRuExtensions.php
+++ b/src/Model/ContactRuExtensions.php
@@ -385,7 +385,12 @@ class ContactRuExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactSportExtensions.php
+++ b/src/Model/ContactSportExtensions.php
@@ -355,7 +355,12 @@ class ContactSportExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactSwissExtensions.php
+++ b/src/Model/ContactSwissExtensions.php
@@ -385,7 +385,12 @@ class ContactSwissExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactTrademarkExtensions.php
+++ b/src/Model/ContactTrademarkExtensions.php
@@ -505,7 +505,12 @@ class ContactTrademarkExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactUkExtensions.php
+++ b/src/Model/ContactUkExtensions.php
@@ -355,7 +355,12 @@ class ContactUkExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactVerification.php
+++ b/src/Model/ContactVerification.php
@@ -751,7 +751,12 @@ class ContactVerification implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactVerificationDomain.php
+++ b/src/Model/ContactVerificationDomain.php
@@ -505,7 +505,12 @@ class ContactVerificationDomain implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactVerificationMessage.php
+++ b/src/Model/ContactVerificationMessage.php
@@ -445,7 +445,12 @@ class ContactVerificationMessage implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ContactXxxExtensions.php
+++ b/src/Model/ContactXxxExtensions.php
@@ -385,7 +385,12 @@ class ContactXxxExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Currency.php
+++ b/src/Model/Currency.php
@@ -330,7 +330,12 @@ class Currency implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/CurrencyRate.php
+++ b/src/Model/CurrencyRate.php
@@ -385,7 +385,12 @@ class CurrencyRate implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Custom.php
+++ b/src/Model/Custom.php
@@ -391,7 +391,12 @@ class Custom implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Customer.php
+++ b/src/Model/Customer.php
@@ -1324,7 +1324,12 @@ class Customer implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/CustomerContract.php
+++ b/src/Model/CustomerContract.php
@@ -478,7 +478,12 @@ class CustomerContract implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DNSSec.php
+++ b/src/Model/DNSSec.php
@@ -482,7 +482,12 @@ class DNSSec implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DNSSecJob.php
+++ b/src/Model/DNSSecJob.php
@@ -330,7 +330,12 @@ class DNSSecJob implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Document.php
+++ b/src/Model/Document.php
@@ -625,7 +625,12 @@ class Document implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Domain.php
+++ b/src/Model/Domain.php
@@ -1924,7 +1924,12 @@ class Domain implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainCancelation.php
+++ b/src/Model/DomainCancelation.php
@@ -727,7 +727,12 @@ class DomainCancelation implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainControllValidationStatus.php
+++ b/src/Model/DomainControllValidationStatus.php
@@ -385,7 +385,12 @@ class DomainControllValidationStatus implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainEnvelope.php
+++ b/src/Model/DomainEnvelope.php
@@ -475,7 +475,12 @@ class DomainEnvelope implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainEnvelopeSearchRequest.php
+++ b/src/Model/DomainEnvelopeSearchRequest.php
@@ -505,7 +505,12 @@ class DomainEnvelopeSearchRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainExtensions.php
+++ b/src/Model/DomainExtensions.php
@@ -415,7 +415,12 @@ class DomainExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainMonitoring.php
+++ b/src/Model/DomainMonitoring.php
@@ -688,7 +688,12 @@ class DomainMonitoring implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainMonitoringSetup.php
+++ b/src/Model/DomainMonitoringSetup.php
@@ -415,7 +415,12 @@ class DomainMonitoringSetup implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainParkingExtensions.php
+++ b/src/Model/DomainParkingExtensions.php
@@ -565,7 +565,12 @@ class DomainParkingExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainPrereg.php
+++ b/src/Model/DomainPrereg.php
@@ -1075,7 +1075,12 @@ class DomainPrereg implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainPreregAddon.php
+++ b/src/Model/DomainPreregAddon.php
@@ -745,7 +745,12 @@ class DomainPreregAddon implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainRestore.php
+++ b/src/Model/DomainRestore.php
@@ -1984,7 +1984,12 @@ class DomainRestore implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainSafeAccount.php
+++ b/src/Model/DomainSafeAccount.php
@@ -601,7 +601,12 @@ class DomainSafeAccount implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainSafeObject.php
+++ b/src/Model/DomainSafeObject.php
@@ -511,7 +511,12 @@ class DomainSafeObject implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainSafeUser.php
+++ b/src/Model/DomainSafeUser.php
@@ -421,7 +421,12 @@ class DomainSafeUser implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainServices.php
+++ b/src/Model/DomainServices.php
@@ -445,7 +445,12 @@ class DomainServices implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainServicesUpdate.php
+++ b/src/Model/DomainServicesUpdate.php
@@ -415,7 +415,12 @@ class DomainServicesUpdate implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainStudio.php
+++ b/src/Model/DomainStudio.php
@@ -330,7 +330,12 @@ class DomainStudio implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainStudioItem.php
+++ b/src/Model/DomainStudioItem.php
@@ -445,7 +445,12 @@ class DomainStudioItem implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainStudioService.php
+++ b/src/Model/DomainStudioService.php
@@ -415,7 +415,12 @@ class DomainStudioService implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainStudioSourceCustom.php
+++ b/src/Model/DomainStudioSourceCustom.php
@@ -385,7 +385,12 @@ class DomainStudioSourceCustom implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainStudioSourceGeo.php
+++ b/src/Model/DomainStudioSourceGeo.php
@@ -385,7 +385,12 @@ class DomainStudioSourceGeo implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainStudioSourceInitial.php
+++ b/src/Model/DomainStudioSourceInitial.php
@@ -385,7 +385,12 @@ class DomainStudioSourceInitial implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainStudioSourceOnlinePresence.php
+++ b/src/Model/DomainStudioSourceOnlinePresence.php
@@ -955,7 +955,12 @@ class DomainStudioSourceOnlinePresence implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainStudioSourcePremium.php
+++ b/src/Model/DomainStudioSourcePremium.php
@@ -445,7 +445,12 @@ class DomainStudioSourcePremium implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainStudioSourceRecommended.php
+++ b/src/Model/DomainStudioSourceRecommended.php
@@ -385,7 +385,12 @@ class DomainStudioSourceRecommended implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainStudioSourceSimilar.php
+++ b/src/Model/DomainStudioSourceSimilar.php
@@ -415,7 +415,12 @@ class DomainStudioSourceSimilar implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainStudioSourceSuggestion.php
+++ b/src/Model/DomainStudioSourceSuggestion.php
@@ -565,7 +565,12 @@ class DomainStudioSourceSuggestion implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainStudioSources.php
+++ b/src/Model/DomainStudioSources.php
@@ -565,7 +565,12 @@ class DomainStudioSources implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/DomainTmchClaimNoticeExtensions.php
+++ b/src/Model/DomainTmchClaimNoticeExtensions.php
@@ -445,7 +445,12 @@ class DomainTmchClaimNoticeExtensions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Domains.php
+++ b/src/Model/Domains.php
@@ -355,7 +355,12 @@ class Domains implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Estimation.php
+++ b/src/Model/Estimation.php
@@ -385,7 +385,12 @@ class Estimation implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/EstimationData.php
+++ b/src/Model/EstimationData.php
@@ -385,7 +385,12 @@ class EstimationData implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/EstimationParameters.php
+++ b/src/Model/EstimationParameters.php
@@ -1165,7 +1165,12 @@ class EstimationParameters implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/EstimationParametersV1.php
+++ b/src/Model/EstimationParametersV1.php
@@ -505,7 +505,12 @@ class EstimationParametersV1 implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/EstimationParametersV1KeywordBased.php
+++ b/src/Model/EstimationParametersV1KeywordBased.php
@@ -745,7 +745,12 @@ class EstimationParametersV1KeywordBased implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/EstimationParametersV1Language.php
+++ b/src/Model/EstimationParametersV1Language.php
@@ -475,7 +475,12 @@ class EstimationParametersV1Language implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/EstimationParametersV1NameBased.php
+++ b/src/Model/EstimationParametersV1NameBased.php
@@ -925,7 +925,12 @@ class EstimationParametersV1NameBased implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/EstimationParametersV1Pagerank.php
+++ b/src/Model/EstimationParametersV1Pagerank.php
@@ -565,7 +565,12 @@ class EstimationParametersV1Pagerank implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/EstimationParametersV1TldBased.php
+++ b/src/Model/EstimationParametersV1TldBased.php
@@ -655,7 +655,12 @@ class EstimationParametersV1TldBased implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/EstimationParametersV1WikipediaPageview.php
+++ b/src/Model/EstimationParametersV1WikipediaPageview.php
@@ -385,7 +385,12 @@ class EstimationParametersV1WikipediaPageview implements ModelInterface, ArrayAc
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/EstimationServiceData.php
+++ b/src/Model/EstimationServiceData.php
@@ -445,7 +445,12 @@ class EstimationServiceData implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/EstimationStatistics.php
+++ b/src/Model/EstimationStatistics.php
@@ -415,7 +415,12 @@ class EstimationStatistics implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/EstimationV1.php
+++ b/src/Model/EstimationV1.php
@@ -535,7 +535,12 @@ class EstimationV1 implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ExchangeRate.php
+++ b/src/Model/ExchangeRate.php
@@ -385,7 +385,12 @@ class ExchangeRate implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ExchangedPrice.php
+++ b/src/Model/ExchangedPrice.php
@@ -928,7 +928,12 @@ class ExchangedPrice implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ExtendedValidationExtension.php
+++ b/src/Model/ExtendedValidationExtension.php
@@ -415,7 +415,12 @@ class ExtendedValidationExtension implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/GenericCustomer.php
+++ b/src/Model/GenericCustomer.php
@@ -436,7 +436,12 @@ class GenericCustomer implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/GenericLabelEntity.php
+++ b/src/Model/GenericLabelEntity.php
@@ -478,7 +478,12 @@ class GenericLabelEntity implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/GenericObject.php
+++ b/src/Model/GenericObject.php
@@ -385,7 +385,12 @@ class GenericObject implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/HistoryUser.php
+++ b/src/Model/HistoryUser.php
@@ -625,7 +625,12 @@ class HistoryUser implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Id4MeAgent.php
+++ b/src/Model/Id4MeAgent.php
@@ -628,7 +628,12 @@ class Id4MeAgent implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Id4meIdentity.php
+++ b/src/Model/Id4meIdentity.php
@@ -811,7 +811,12 @@ class Id4meIdentity implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/InetAddress.php
+++ b/src/Model/InetAddress.php
@@ -330,7 +330,12 @@ class InetAddress implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Invoice.php
+++ b/src/Model/Invoice.php
@@ -985,7 +985,12 @@ class Invoice implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/IpRestriction.php
+++ b/src/Model/IpRestriction.php
@@ -451,7 +451,12 @@ class IpRestriction implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/IpRestrictions.php
+++ b/src/Model/IpRestrictions.php
@@ -355,7 +355,12 @@ class IpRestrictions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Job.php
+++ b/src/Model/Job.php
@@ -655,7 +655,12 @@ class Job implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonNoData.php
+++ b/src/Model/JsonNoData.php
@@ -330,7 +330,12 @@ class JsonNoData implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseData.php
+++ b/src/Model/JsonResponseData.php
@@ -505,7 +505,12 @@ class JsonResponseData implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataBackupMx.php
+++ b/src/Model/JsonResponseDataBackupMx.php
@@ -505,7 +505,12 @@ class JsonResponseDataBackupMx implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataByte_.php
+++ b/src/Model/JsonResponseDataByte_.php
@@ -505,7 +505,12 @@ class JsonResponseDataByte_ implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataCertificate.php
+++ b/src/Model/JsonResponseDataCertificate.php
@@ -505,7 +505,12 @@ class JsonResponseDataCertificate implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataCertificateData.php
+++ b/src/Model/JsonResponseDataCertificateData.php
@@ -505,7 +505,12 @@ class JsonResponseDataCertificateData implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataContact.php
+++ b/src/Model/JsonResponseDataContact.php
@@ -505,7 +505,12 @@ class JsonResponseDataContact implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataContactVerification.php
+++ b/src/Model/JsonResponseDataContactVerification.php
@@ -505,7 +505,12 @@ class JsonResponseDataContactVerification implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataDomain.php
+++ b/src/Model/JsonResponseDataDomain.php
@@ -505,7 +505,12 @@ class JsonResponseDataDomain implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataDomainCancelation.php
+++ b/src/Model/JsonResponseDataDomainCancelation.php
@@ -505,7 +505,12 @@ class JsonResponseDataDomainCancelation implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataDomainEnvelope.php
+++ b/src/Model/JsonResponseDataDomainEnvelope.php
@@ -505,7 +505,12 @@ class JsonResponseDataDomainEnvelope implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataDomainPrereg.php
+++ b/src/Model/JsonResponseDataDomainPrereg.php
@@ -505,7 +505,12 @@ class JsonResponseDataDomainPrereg implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataDomainRestore.php
+++ b/src/Model/JsonResponseDataDomainRestore.php
@@ -505,7 +505,12 @@ class JsonResponseDataDomainRestore implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataDomainSafeAccount.php
+++ b/src/Model/JsonResponseDataDomainSafeAccount.php
@@ -505,7 +505,12 @@ class JsonResponseDataDomainSafeAccount implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataDomainSafeObject.php
+++ b/src/Model/JsonResponseDataDomainSafeObject.php
@@ -505,7 +505,12 @@ class JsonResponseDataDomainSafeObject implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataDomainSafeUser.php
+++ b/src/Model/JsonResponseDataDomainSafeUser.php
@@ -505,7 +505,12 @@ class JsonResponseDataDomainSafeUser implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataId4MeAgent.php
+++ b/src/Model/JsonResponseDataId4MeAgent.php
@@ -505,7 +505,12 @@ class JsonResponseDataId4MeAgent implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataId4meIdentity.php
+++ b/src/Model/JsonResponseDataId4meIdentity.php
@@ -505,7 +505,12 @@ class JsonResponseDataId4meIdentity implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataInvoice.php
+++ b/src/Model/JsonResponseDataInvoice.php
@@ -505,7 +505,12 @@ class JsonResponseDataInvoice implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataJsonNoData.php
+++ b/src/Model/JsonResponseDataJsonNoData.php
@@ -505,7 +505,12 @@ class JsonResponseDataJsonNoData implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataListJsonResponseDataBackupMx.php
+++ b/src/Model/JsonResponseDataListJsonResponseDataBackupMx.php
@@ -505,7 +505,12 @@ class JsonResponseDataListJsonResponseDataBackupMx implements ModelInterface, Ar
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataListJsonResponseDataDomain.php
+++ b/src/Model/JsonResponseDataListJsonResponseDataDomain.php
@@ -505,7 +505,12 @@ class JsonResponseDataListJsonResponseDataDomain implements ModelInterface, Arra
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataListJsonResponseDataDomainCancelation.php
+++ b/src/Model/JsonResponseDataListJsonResponseDataDomainCancelation.php
@@ -505,7 +505,12 @@ class JsonResponseDataListJsonResponseDataDomainCancelation implements ModelInte
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataListJsonResponseDataDomainPrereg.php
+++ b/src/Model/JsonResponseDataListJsonResponseDataDomainPrereg.php
@@ -505,7 +505,12 @@ class JsonResponseDataListJsonResponseDataDomainPrereg implements ModelInterface
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataListJsonResponseDataMailProxy.php
+++ b/src/Model/JsonResponseDataListJsonResponseDataMailProxy.php
@@ -505,7 +505,12 @@ class JsonResponseDataListJsonResponseDataMailProxy implements ModelInterface, A
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataListJsonResponseDataObjectUserAssignment.php
+++ b/src/Model/JsonResponseDataListJsonResponseDataObjectUserAssignment.php
@@ -505,7 +505,12 @@ class JsonResponseDataListJsonResponseDataObjectUserAssignment implements ModelI
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataListJsonResponseDataRedirect.php
+++ b/src/Model/JsonResponseDataListJsonResponseDataRedirect.php
@@ -505,7 +505,12 @@ class JsonResponseDataListJsonResponseDataRedirect implements ModelInterface, Ar
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataListJsonResponseDataZone.php
+++ b/src/Model/JsonResponseDataListJsonResponseDataZone.php
@@ -505,7 +505,12 @@ class JsonResponseDataListJsonResponseDataZone implements ModelInterface, ArrayA
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataMailProxy.php
+++ b/src/Model/JsonResponseDataMailProxy.php
@@ -505,7 +505,12 @@ class JsonResponseDataMailProxy implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataMailServiceMessage.php
+++ b/src/Model/JsonResponseDataMailServiceMessage.php
@@ -505,7 +505,12 @@ class JsonResponseDataMailServiceMessage implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataOTPAuth.php
+++ b/src/Model/JsonResponseDataOTPAuth.php
@@ -505,7 +505,12 @@ class JsonResponseDataOTPAuth implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataObjectJob.php
+++ b/src/Model/JsonResponseDataObjectJob.php
@@ -505,7 +505,12 @@ class JsonResponseDataObjectJob implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataObjectUserAssignment.php
+++ b/src/Model/JsonResponseDataObjectUserAssignment.php
@@ -505,7 +505,12 @@ class JsonResponseDataObjectUserAssignment implements ModelInterface, ArrayAcces
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataPeriodicBilling.php
+++ b/src/Model/JsonResponseDataPeriodicBilling.php
@@ -505,7 +505,12 @@ class JsonResponseDataPeriodicBilling implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataPollMessage.php
+++ b/src/Model/JsonResponseDataPollMessage.php
@@ -505,7 +505,12 @@ class JsonResponseDataPollMessage implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataRedirect.php
+++ b/src/Model/JsonResponseDataRedirect.php
@@ -505,7 +505,12 @@ class JsonResponseDataRedirect implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataSslContact.php
+++ b/src/Model/JsonResponseDataSslContact.php
@@ -505,7 +505,12 @@ class JsonResponseDataSslContact implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataString.php
+++ b/src/Model/JsonResponseDataString.php
@@ -505,7 +505,12 @@ class JsonResponseDataString implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataTmchMark.php
+++ b/src/Model/JsonResponseDataTmchMark.php
@@ -505,7 +505,12 @@ class JsonResponseDataTmchMark implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataTmchMarkDocument.php
+++ b/src/Model/JsonResponseDataTmchMarkDocument.php
@@ -505,7 +505,12 @@ class JsonResponseDataTmchMarkDocument implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataTransfer.php
+++ b/src/Model/JsonResponseDataTransfer.php
@@ -505,7 +505,12 @@ class JsonResponseDataTransfer implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataTransferOut.php
+++ b/src/Model/JsonResponseDataTransferOut.php
@@ -505,7 +505,12 @@ class JsonResponseDataTransferOut implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataTrustedApplication.php
+++ b/src/Model/JsonResponseDataTrustedApplication.php
@@ -505,7 +505,12 @@ class JsonResponseDataTrustedApplication implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataUser.php
+++ b/src/Model/JsonResponseDataUser.php
@@ -505,7 +505,12 @@ class JsonResponseDataUser implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataVoid.php
+++ b/src/Model/JsonResponseDataVoid.php
@@ -505,7 +505,12 @@ class JsonResponseDataVoid implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/JsonResponseDataZone.php
+++ b/src/Model/JsonResponseDataZone.php
@@ -505,7 +505,12 @@ class JsonResponseDataZone implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Keyword.php
+++ b/src/Model/Keyword.php
@@ -445,7 +445,12 @@ class Keyword implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Keywords.php
+++ b/src/Model/Keywords.php
@@ -355,7 +355,12 @@ class Keywords implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/LoginData.php
+++ b/src/Model/LoginData.php
@@ -460,7 +460,12 @@ class LoginData implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/MailList.php
+++ b/src/Model/MailList.php
@@ -355,7 +355,12 @@ class MailList implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/MailProxy.php
+++ b/src/Model/MailProxy.php
@@ -949,7 +949,12 @@ class MailProxy implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/MailServiceMessage.php
+++ b/src/Model/MailServiceMessage.php
@@ -565,7 +565,12 @@ class MailServiceMessage implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/MainIp.php
+++ b/src/Model/MainIp.php
@@ -385,7 +385,12 @@ class MainIp implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Majestic.php
+++ b/src/Model/Majestic.php
@@ -2485,7 +2485,12 @@ class Majestic implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -475,7 +475,12 @@ class Message implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Meta.php
+++ b/src/Model/Meta.php
@@ -625,7 +625,12 @@ class Meta implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Modifier.php
+++ b/src/Model/Modifier.php
@@ -418,7 +418,12 @@ class Modifier implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Name.php
+++ b/src/Model/Name.php
@@ -330,7 +330,12 @@ class Name implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/NameServer.php
+++ b/src/Model/NameServer.php
@@ -418,7 +418,12 @@ class NameServer implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/NewPassword.php
+++ b/src/Model/NewPassword.php
@@ -595,7 +595,12 @@ class NewPassword implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/NicMember.php
+++ b/src/Model/NicMember.php
@@ -385,7 +385,12 @@ class NicMember implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/NiccomLog.php
+++ b/src/Model/NiccomLog.php
@@ -565,7 +565,12 @@ class NiccomLog implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/NotifyMessage.php
+++ b/src/Model/NotifyMessage.php
@@ -355,7 +355,12 @@ class NotifyMessage implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/OTPAuth.php
+++ b/src/Model/OTPAuth.php
@@ -683,7 +683,12 @@ class OTPAuth implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ObjectJob.php
+++ b/src/Model/ObjectJob.php
@@ -475,7 +475,12 @@ class ObjectJob implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ObjectUserAssignment.php
+++ b/src/Model/ObjectUserAssignment.php
@@ -529,7 +529,12 @@ class ObjectUserAssignment implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/PeriodicBilling.php
+++ b/src/Model/PeriodicBilling.php
@@ -685,7 +685,12 @@ class PeriodicBilling implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Phone.php
+++ b/src/Model/Phone.php
@@ -330,7 +330,12 @@ class Phone implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/PhysicalNameServerGroup.php
+++ b/src/Model/PhysicalNameServerGroup.php
@@ -505,7 +505,12 @@ class PhysicalNameServerGroup implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/PollMessage.php
+++ b/src/Model/PollMessage.php
@@ -625,7 +625,12 @@ class PollMessage implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/PreregConfig.php
+++ b/src/Model/PreregConfig.php
@@ -838,7 +838,12 @@ class PreregConfig implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/PriceData.php
+++ b/src/Model/PriceData.php
@@ -355,7 +355,12 @@ class PriceData implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/PriceServiceData.php
+++ b/src/Model/PriceServiceData.php
@@ -445,7 +445,12 @@ class PriceServiceData implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/PriceServiceEntity.php
+++ b/src/Model/PriceServiceEntity.php
@@ -385,7 +385,12 @@ class PriceServiceEntity implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Query.php
+++ b/src/Model/Query.php
@@ -415,7 +415,12 @@ class Query implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/QueryFilter.php
+++ b/src/Model/QueryFilter.php
@@ -475,7 +475,12 @@ class QueryFilter implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/QueryOrder.php
+++ b/src/Model/QueryOrder.php
@@ -415,7 +415,12 @@ class QueryOrder implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/QueryView.php
+++ b/src/Model/QueryView.php
@@ -475,7 +475,12 @@ class QueryView implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Recipient.php
+++ b/src/Model/Recipient.php
@@ -595,7 +595,12 @@ class Recipient implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/RecipientLog.php
+++ b/src/Model/RecipientLog.php
@@ -475,7 +475,12 @@ class RecipientLog implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Redirect.php
+++ b/src/Model/Redirect.php
@@ -751,7 +751,12 @@ class Redirect implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ResourceRecord.php
+++ b/src/Model/ResourceRecord.php
@@ -517,7 +517,12 @@ class ResourceRecord implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ResponseObject.php
+++ b/src/Model/ResponseObject.php
@@ -445,7 +445,12 @@ class ResponseObject implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ResponseStatus.php
+++ b/src/Model/ResponseStatus.php
@@ -415,7 +415,12 @@ class ResponseStatus implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/SEPAMandate.php
+++ b/src/Model/SEPAMandate.php
@@ -694,7 +694,12 @@ class SEPAMandate implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ServiceEntity.php
+++ b/src/Model/ServiceEntity.php
@@ -418,7 +418,12 @@ class ServiceEntity implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ServiceProfiles.php
+++ b/src/Model/ServiceProfiles.php
@@ -355,7 +355,12 @@ class ServiceProfiles implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ServiceUsersProfile.php
+++ b/src/Model/ServiceUsersProfile.php
@@ -511,7 +511,12 @@ class ServiceUsersProfile implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/SimilarDomain.php
+++ b/src/Model/SimilarDomain.php
@@ -385,7 +385,12 @@ class SimilarDomain implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/SimplePrice.php
+++ b/src/Model/SimplePrice.php
@@ -595,7 +595,12 @@ class SimplePrice implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Sistrix.php
+++ b/src/Model/Sistrix.php
@@ -445,7 +445,12 @@ class Sistrix implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Soa.php
+++ b/src/Model/Soa.php
@@ -478,7 +478,12 @@ class Soa implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/SocialMedia.php
+++ b/src/Model/SocialMedia.php
@@ -475,7 +475,12 @@ class SocialMedia implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/SpamPolicy.php
+++ b/src/Model/SpamPolicy.php
@@ -532,7 +532,12 @@ class SpamPolicy implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/SslContact.php
+++ b/src/Model/SslContact.php
@@ -850,7 +850,12 @@ class SslContact implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/StatisticsParameters.php
+++ b/src/Model/StatisticsParameters.php
@@ -445,7 +445,12 @@ class StatisticsParameters implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/SubjectAlternativeName.php
+++ b/src/Model/SubjectAlternativeName.php
@@ -415,7 +415,12 @@ class SubjectAlternativeName implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -775,7 +775,12 @@ class Subscription implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/TimePeriod.php
+++ b/src/Model/TimePeriod.php
@@ -385,7 +385,12 @@ class TimePeriod implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/TmchContact.php
+++ b/src/Model/TmchContact.php
@@ -661,7 +661,12 @@ class TmchContact implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/TmchMark.php
+++ b/src/Model/TmchMark.php
@@ -1069,7 +1069,12 @@ class TmchMark implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/TmchMarkAddon.php
+++ b/src/Model/TmchMarkAddon.php
@@ -685,7 +685,12 @@ class TmchMarkAddon implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/TmchMarkComment.php
+++ b/src/Model/TmchMarkComment.php
@@ -475,7 +475,12 @@ class TmchMarkComment implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/TmchMarkDocument.php
+++ b/src/Model/TmchMarkDocument.php
@@ -451,7 +451,12 @@ class TmchMarkDocument implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Transfer.php
+++ b/src/Model/Transfer.php
@@ -868,7 +868,12 @@ class Transfer implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/TransferOut.php
+++ b/src/Model/TransferOut.php
@@ -931,7 +931,12 @@ class TransferOut implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/TrustedApplication.php
+++ b/src/Model/TrustedApplication.php
@@ -691,7 +691,12 @@ class TrustedApplication implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/TrustedApplicationFunctions.php
+++ b/src/Model/TrustedApplicationFunctions.php
@@ -355,7 +355,12 @@ class TrustedApplicationFunctions implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/UrlEntity.php
+++ b/src/Model/UrlEntity.php
@@ -330,7 +330,12 @@ class UrlEntity implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1030,7 +1030,12 @@ class User implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/UserAcl.php
+++ b/src/Model/UserAcl.php
@@ -565,7 +565,12 @@ class UserAcl implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/UserAcls.php
+++ b/src/Model/UserAcls.php
@@ -388,7 +388,12 @@ class UserAcls implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/UserDetails.php
+++ b/src/Model/UserDetails.php
@@ -505,7 +505,12 @@ class UserDetails implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/UserEstimationStatistics.php
+++ b/src/Model/UserEstimationStatistics.php
@@ -445,7 +445,12 @@ class UserEstimationStatistics implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/UserEstimationStatisticsLast12MonthsDevelopment.php
+++ b/src/Model/UserEstimationStatisticsLast12MonthsDevelopment.php
@@ -415,7 +415,12 @@ class UserEstimationStatisticsLast12MonthsDevelopment implements ModelInterface,
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/UserProfile.php
+++ b/src/Model/UserProfile.php
@@ -574,7 +574,12 @@ class UserProfile implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/UserProfileViews.php
+++ b/src/Model/UserProfileViews.php
@@ -355,7 +355,12 @@ class UserProfileViews implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/VhostCertificate.php
+++ b/src/Model/VhostCertificate.php
@@ -445,7 +445,12 @@ class VhostCertificate implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/VirtualNameServer.php
+++ b/src/Model/VirtualNameServer.php
@@ -565,7 +565,12 @@ class VirtualNameServer implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/VirtualNameServerGroup.php
+++ b/src/Model/VirtualNameServerGroup.php
@@ -568,7 +568,12 @@ class VirtualNameServerGroup implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Void.php
+++ b/src/Model/Void.php
@@ -330,7 +330,12 @@ class Void implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Wayback.php
+++ b/src/Model/Wayback.php
@@ -355,7 +355,12 @@ class Wayback implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/WaybackWayback.php
+++ b/src/Model/WaybackWayback.php
@@ -385,7 +385,12 @@ class WaybackWayback implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/WaybackWaybackArchivedSnapshots.php
+++ b/src/Model/WaybackWaybackArchivedSnapshots.php
@@ -355,7 +355,12 @@ class WaybackWaybackArchivedSnapshots implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/WaybackWaybackArchivedSnapshotsClosest.php
+++ b/src/Model/WaybackWaybackArchivedSnapshotsClosest.php
@@ -445,7 +445,12 @@ class WaybackWaybackArchivedSnapshotsClosest implements ModelInterface, ArrayAcc
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/WhoisServiceData.php
+++ b/src/Model/WhoisServiceData.php
@@ -445,7 +445,12 @@ class WhoisServiceData implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/WhoisStatus.php
+++ b/src/Model/WhoisStatus.php
@@ -355,7 +355,12 @@ class WhoisStatus implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/WorkflowEvent.php
+++ b/src/Model/WorkflowEvent.php
@@ -385,7 +385,12 @@ class WorkflowEvent implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/WorkflowSpool.php
+++ b/src/Model/WorkflowSpool.php
@@ -565,7 +565,12 @@ class WorkflowSpool implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/Zone.php
+++ b/src/Model/Zone.php
@@ -1048,7 +1048,12 @@ class Zone implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ZoneBasePatchRequest.php
+++ b/src/Model/ZoneBasePatchRequest.php
@@ -1168,7 +1168,12 @@ class ZoneBasePatchRequest implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }

--- a/src/Model/ZoneStream.php
+++ b/src/Model/ZoneStream.php
@@ -385,7 +385,12 @@ class ZoneStream implements ModelInterface, ArrayAccess
     public function toArray($retrieveAllValues = false){
         $container = $this->container;
         foreach ($container as $key => &$value) {
-            if (!$retrieveAllValues && $value !== FALSE && $value !== '') {
+            if (
+                $retrieveAllValues === false && 
+                empty($value) === true && 
+                $value !== false && 
+                $value !== ''
+            ) {
                 unset($container[$key]);
                 continue;
             }


### PR DESCRIPTION
Fixed Bug in last Commit: toArray() retrieveAllValues allow FALSE and empty Strings

Signed-off-by: Christian Pleintinger <christian.pleintinger@intranetx.com>