### PR TITLE
Fixed ErrorException

### DIFF
--- a/src/Model/Domain.php
+++ b/src/Model/Domain.php
@@ -489,7 +489,7 @@ class Domain implements ModelInterface, ArrayAccess
      * @param string $property
      * @return mixed
      */
-    public function createData($data = null, $property)
+    public function createData($data = null, $property = null)
     {
         if ($data === null) {
             return '';


### PR DESCRIPTION
**Fix Required parameter $property follows optional parameter $data**

The package was throwing an error in php 8+, when using the domain model (getting info about a domain).

I fixed it by making the last parameter also optional with = null.

The following code was giving the error:

`$autodns->domain->info($name)`

This is fixed now.